### PR TITLE
Add C++ and CMake pre-commit hooks

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,11 @@
+name: pre-commit
+
+on:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  call_reusable_workflow:
+    uses: vortexntnu/vortex-ci/.github/workflows/reusable-pre-commit.yml@main
+    with:
+        ros_distro: 'humble'
+        config_path: '.pre-commit-config-local.yaml'

--- a/.pre-commit-config-local.yaml
+++ b/.pre-commit-config-local.yaml
@@ -1,0 +1,44 @@
+# To use:
+#
+#     pre-commit run --all-files -c .pre-commit-config-local.yaml
+#
+# Or to install it for automatic checks on commit:
+#
+#     pre-commit install -c .pre-commit-config-local.yaml
+#
+# To update this file:
+#
+#     pre-commit autoupdate -c .pre-commit-config-local.yaml
+#
+# See https://pre-commit.com/ for documentation
+#
+# NOTE: This configuration uses local hooks specific to ROS2 (ament_* linters)
+
+repos:
+  # C++ hooks
+  - repo: local
+    hooks:
+      - id: ament_cppcheck
+        name: ament_cppcheck
+        description: Static code analysis of C/C++ files.
+        entry: env AMENT_CPPCHECK_ALLOW_SLOW_VERSIONS=1 ament_cppcheck
+        language: system
+        files: \.(h\+\+|h|hh|hxx|hpp|cuh|c|cc|cpp|cu|c\+\+|cxx|tpp|txx)$
+  - repo: local
+    hooks:
+      - id: ament_cpplint
+        name: ament_cpplint
+        description: Static code analysis of C/C++ files.
+        entry: ament_cpplint
+        language: system
+        files: \.(h\+\+|h|hh|hxx|hpp|cuh|c|cc|cpp|cu|c\+\+|cxx|tpp|txx)$
+        args: ["--linelength=100", "--filter=-whitespace/newline,-legal/copyright"]
+  # CMake hooks
+  - repo: local
+    hooks:
+      - id: ament_lint_cmake
+        name: ament_lint_cmake
+        description: Check format of CMakeLists.txt files.
+        entry: ament_lint_cmake
+        language: system
+        files: CMakeLists\.txt$


### PR DESCRIPTION
This PR adds ROS 2 pre-commit hooks for C++ (cppcheck, cpplint) and CMake (ament_lint_cmake), along with a GitHub Actions workflow to run them since they are not supported by pre-commit ci

Remaining work: Fix the issues flagged by the new hooks.